### PR TITLE
Выбор версии GitHub-конфигурации

### DIFF
--- a/remote-control/modules/github-config.sh
+++ b/remote-control/modules/github-config.sh
@@ -77,6 +77,71 @@ _github_ensure_deps() {
         [[ "$mode" != age ]] || _github_require "$AGE_BIN"
     fi
 }
+_github_select_account() {
+    local gh="${GH_BIN:-gh}" login answer switch_stderr switch_output
+    if ! _github_ensure_deps; then
+        _github_record_error "проверка зависимостей" \
+            "Не удалось подготовить GitHub CLI для выбора аккаунта."
+        return 1
+    fi
+    if ! _github_require "$gh"; then
+        _github_record_error "проверка зависимостей" \
+            "Не найдена команда GitHub CLI: $gh."
+        return 1
+    fi
+    while :; do
+        if ! login=$(NO_COLOR=1 GH_PROMPT_DISABLED=1 "$gh" api user --jq .login 2>&1); then
+            _github_record_error "определение пользователя GitHub" \
+                "${login}. Выполните: gh auth login." true
+            return 1
+        fi
+        login=$(printf '%s' "$login" | tr -d '\r\n')
+        [[ -n "$login" ]] || {
+            _github_record_error "определение пользователя GitHub" \
+                "GitHub CLI не вернул имя активного аккаунта." true
+            return 1
+        }
+        info "GitHub-аккаунт для репозитория конфигурации: $login"
+        echo -e "  ${GREEN}1)${NC} Использовать этот аккаунт"
+        echo -e "  ${CYAN}2)${NC} Выбрать другой аккаунт"
+        echo -e "  ${RED}0)${NC} Отмена"
+        if ! read -rp "  Выберите действие: " answer; then
+            _github_record_error "выбор аккаунта GitHub" \
+                "Выбор аккаунта GitHub отменён."
+            return 1
+        fi
+        case "$answer" in
+            1)
+                GITHUB_OWNER="$login"
+                export GITHUB_OWNER
+                return 0
+                ;;
+            2)
+                switch_stderr=$(umask 077; mktemp "${TMPDIR:-/tmp}/github-switch.XXXXXX") || {
+                    _github_record_error "переключение аккаунта GitHub" \
+                        "Не удалось подготовить безопасную диагностику переключения аккаунта." true
+                    return 1
+                }
+                if ! NO_COLOR=1 "$gh" auth switch --hostname github.com \
+                    2>"$switch_stderr"; then
+                    switch_output=$(cat "$switch_stderr")
+                    rm -f "$switch_stderr"
+                    _github_record_error "переключение аккаунта GitHub" \
+                        "${switch_output:-Не удалось переключить аккаунт GitHub.} Выполните: gh auth login." true
+                    return 1
+                fi
+                rm -f "$switch_stderr"
+                ;;
+            0)
+                _github_record_error "выбор аккаунта GitHub" \
+                    "Выбор аккаунта GitHub отменён."
+                return 1
+                ;;
+            *) warn "Неверный выбор." ;;
+        esac
+    done
+}
+
 
 _github_run_with_timeout() {
     run_with_timeout "$@"
@@ -114,6 +179,29 @@ _github_prompt_storage_mode() {
         echo -e "  ${CYAN}2)${NC} Хранить без шифрования"
         read -rp "  Выберите 1 или 2: " answer
         case "$answer" in 1) GITHUB_STORAGE_MODE=age; return 0;; 2) GITHUB_STORAGE_MODE=none; return 0;; esac
+    done
+}
+_github_prompt_existing_config_action() {
+    local answer mode_label
+    case "${GITHUB_STORAGE_MODE:-}" in
+        age) mode_label="зашифровано паролем" ;;
+        none) mode_label="без шифрования" ;;
+        *) return 1 ;;
+    esac
+    info "В GitHub уже сохранена конфигурация (режим хранения: $mode_label)."
+    while :; do
+        echo "  1) Загрузить конфигурацию из GitHub"
+        echo "  2) Заменить конфигурацию в GitHub текущей локальной"
+        echo "  0) Отмена"
+        if ! IFS= read -rp "  Выберите действие: " answer; then
+            return 1
+        fi
+        case "$answer" in
+            1) GITHUB_EXISTING_ACTION=remote; return 0 ;;
+            2) GITHUB_EXISTING_ACTION=local; return 0 ;;
+            0) return 1 ;;
+            *) warn "Неверный выбор." ;;
+        esac
     done
 }
 _github_prompt_remember_unlock() {
@@ -567,6 +655,42 @@ github_config_open() {
 }
 
 _github_repo() { printf '%s/%s' "${GITHUB_OWNER:?}" "$GITHUB_REPO_NAME"; }
+github_repository_delete() {
+    local repo="${1:-}" gh="${GH_BIN:-gh}" output
+    if [[ ! "$repo" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; then
+        _github_record_error "удаление репозитория GitHub" \
+            "Указан некорректный репозиторий GitHub."
+        return 1
+    fi
+    if ! github_config_switch_local; then
+        _github_record_error "сохранение локальной конфигурации перед удалением" \
+            "Не удалось сохранить конфигурацию локально."
+        return 1
+    fi
+    if ! _github_ensure_deps "" "https://github.com/$repo.git"; then
+        _github_record_error "проверка зависимостей" \
+            "Не удалось подготовить GitHub CLI."
+        return 1
+    fi
+    if ! _github_require "$gh"; then
+        _github_record_error "проверка зависимостей" \
+            "Не найдена команда GitHub CLI: $gh."
+        return 1
+    fi
+    if ! output=$(NO_COLOR=1 GH_PROMPT_DISABLED=1 "$gh" repo delete "$repo" --yes 2>&1); then
+        _github_record_error "удаление репозитория GitHub" "$output" true
+        return 1
+    fi
+}
+
+github_repository_open_settings() {
+    local repo="${1:-}" gh="${GH_BIN:-gh}"
+    [[ "$repo" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]] || return 1
+    _github_require "$gh" || return 1
+    NO_COLOR=1 GH_PROMPT_DISABLED=1 "$gh" browse --settings --repo "$repo" \
+        >/dev/null 2>&1
+}
+
 github_source_metadata_valid() {
     local file="${1:-}"
     [[ -f "$file" ]] || return 1
@@ -609,8 +733,20 @@ legacy_local_source_metadata_valid() {
 }
 
 
+_github_archive_oid() {
+    local oid="${1:-}" label="${2:-archive}" archive_ref
+    [[ -n "$oid" ]] || return 0
+    archive_ref="refs/archive/${label}-$(date -u +%Y%m%dT%H%M%SZ)-$$"
+    git --git-dir="$GITHUB_STORE" update-ref "$archive_ref" "$oid"
+}
+
 github_sync_init() {
-    local announce_account="${1:-false}"
+    local allow_create="${1:-false}"
+    local init_mode="${2:-resume}"
+    case "$init_mode" in
+        resume|onboarding) ;;
+        *) _github_record_error "подготовка локального репозитория" "Неизвестный режим инициализации GitHub."; return 1 ;;
+    esac
     # github_enable_local may initialize the transport before calling
     # config_source_startup. Reuse that live worktree instead of attempting
     # to create the same session branch a second time.
@@ -649,20 +785,29 @@ github_sync_init() {
             _github_record_error "определение пользователя GitHub" "$login" true
             return 1
         fi
+        login=$(printf '%s' "$login" | tr -d '\r\n')
         [[ -n "$GITHUB_OWNER" ]] || GITHUB_OWNER="$login"
         if [[ "$login" != "$GITHUB_OWNER" ]]; then
             _github_record_error "проверка пользователя GitHub" \
                 "GitHub CLI подключён как $login, ожидался пользователь $GITHUB_OWNER."
             return 1
         fi
-        if [[ "$announce_account" == true ]]; then
-            info "GitHub-аккаунт для репозитория конфигурации: $login"
-        fi
         repo="$GITHUB_OWNER/$GITHUB_REPO_NAME"
         if ! remote_view=$(NO_COLOR=1 GH_PROMPT_DISABLED=1 "$gh" repo view "$repo" --json visibility 2>&1); then
             if [[ "$remote_view" != *"not found"* &&
                   "$remote_view" != *"Could not resolve to a Repository"* ]]; then
                 _github_record_error "проверка приватного репозитория" "$remote_view" true
+                return 1
+            fi
+            if [[ "$allow_create" != true ]]; then
+                _github_record_error "проверка приватного репозитория" \
+                    "Репозиторий $repo не найден."
+                return 1
+            fi
+            info "Репозиторий $repo не найден."
+            if ! confirm_yn "Создать приватный репозиторий $repo?" N; then
+                _github_record_error "создание приватного репозитория" \
+                    "Создание репозитория $repo отменено."
                 return 1
             fi
             if ! create_output=$(NO_COLOR=1 GH_PROMPT_DISABLED=1 "$gh" repo create "$repo" \
@@ -716,7 +861,61 @@ github_sync_init() {
     remote_ref="refs/remotes/origin/$GITHUB_BRANCH"
     fetch_output=$(GIT_TERMINAL_PROMPT=0 _github_run_with_timeout 30 \
         git --git-dir="$GITHUB_STORE" fetch --no-tags origin "$GITHUB_BRANCH" 2>&1) || fetch_ok=false
-    if [[ "$fetch_ok" == true ]] &&
+
+    if [[ "$init_mode" == onboarding ]]; then
+        if [[ "$fetch_ok" == true ]] &&
+           git --git-dir="$GITHUB_STORE" show-ref --verify --quiet "$remote_ref"; then
+            remote_oid=$(git --git-dir="$GITHUB_STORE" rev-parse "$remote_ref") || return 1
+            if git --git-dir="$GITHUB_STORE" show-ref --verify --quiet "$local_ref"; then
+                local_oid=$(git --git-dir="$GITHUB_STORE" rev-parse "$local_ref") || return 1
+                if [[ "$local_oid" != "$remote_oid" ]] &&
+                   ! git --git-dir="$GITHUB_STORE" merge-base --is-ancestor \
+                        "$local_ref" "$remote_ref"; then
+                    if ! _github_archive_oid "$local_oid" onboarding; then
+                        _github_record_error "сохранение локальной истории перед подключением" \
+                            "Не удалось сохранить локальную ветку перед выбором версии конфигурации."
+                        return 1
+                    fi
+                fi
+            fi
+            if ! git --git-dir="$GITHUB_STORE" update-ref "$local_ref" "$remote_ref"; then
+                _github_record_error "обновление локальной копии репозитория" \
+                    "Не удалось подготовить локальную ветку конфигурации."
+                return 1
+            fi
+            GITHUB_SYNC_STATUS=clean
+        else
+            if ! remote_refs=$(_github_run_with_timeout 15 git ls-remote \
+                "$GITHUB_REMOTE" "refs/heads/$GITHUB_BRANCH" 2>/dev/null); then
+                if [[ "$GITHUB_REMOTE" == https://github.com/* ]]; then
+                    _github_record_error "загрузка репозитория GitHub" "$fetch_output" true
+                else
+                    _github_record_error "загрузка репозитория GitHub" "$fetch_output"
+                fi
+                return 1
+            fi
+            if [[ -n "$remote_refs" ]]; then
+                if [[ "$GITHUB_REMOTE" == https://github.com/* ]]; then
+                    _github_record_error "загрузка репозитория GitHub" "$fetch_output" true
+                else
+                    _github_record_error "загрузка репозитория GitHub" "$fetch_output"
+                fi
+                return 1
+            fi
+            local previous_oid=""
+            if git --git-dir="$GITHUB_STORE" show-ref --verify --quiet "$local_ref"; then
+                previous_oid=$(git --git-dir="$GITHUB_STORE" rev-parse "$local_ref") || return 1
+                if ! _github_archive_oid "$previous_oid" onboarding; then
+                    _github_record_error "сохранение локальной истории перед подключением" \
+                        "Не удалось сохранить локальную ветку перед выбором версии конфигурации."
+                    return 1
+                fi
+            fi
+            git --git-dir="$GITHUB_STORE" update-ref -d "$local_ref" || return 1
+            git --git-dir="$GITHUB_STORE" update-ref -d "$remote_ref" || return 1
+            GITHUB_SYNC_STATUS=clean
+        fi
+    elif [[ "$fetch_ok" == true ]] &&
        git --git-dir="$GITHUB_STORE" show-ref --verify --quiet "$remote_ref"; then
         remote_oid=$(git --git-dir="$GITHUB_STORE" rev-parse "$remote_ref") || return 1
         if ! git --git-dir="$GITHUB_STORE" show-ref --verify --quiet "$local_ref"; then
@@ -753,20 +952,17 @@ github_sync_init() {
             if remote_refs=$(_github_run_with_timeout 15 git ls-remote \
                 "$GITHUB_REMOTE" "refs/heads/$GITHUB_BRANCH" 2>/dev/null) &&
                [[ -z "$remote_refs" ]]; then
-                local previous_oid="" archive_ref
+                local previous_oid=""
                 if git --git-dir="$GITHUB_STORE" show-ref --verify --quiet "$local_ref"; then
                     previous_oid=$(git --git-dir="$GITHUB_STORE" rev-parse "$local_ref")
                 elif git --git-dir="$GITHUB_STORE" show-ref --verify --quiet "$remote_ref"; then
                     previous_oid=$(git --git-dir="$GITHUB_STORE" rev-parse "$remote_ref")
                 fi
-                if [[ -n "$previous_oid" ]]; then
-                    archive_ref="refs/archive/remote-switch-$(date -u +%Y%m%dT%H%M%SZ)-$$"
-                    if ! git --git-dir="$GITHUB_STORE" update-ref \
-                        "$archive_ref" "$previous_oid"; then
-                        _github_record_error "сохранение истории прежнего репозитория" \
-                            "Не удалось сохранить прежнюю локальную ветку перед сменой репозитория."
-                        return 1
-                    fi
+                if [[ -n "$previous_oid" ]] &&
+                   ! _github_archive_oid "$previous_oid" remote-switch; then
+                    _github_record_error "сохранение истории прежнего репозитория" \
+                        "Не удалось сохранить прежнюю локальную ветку перед сменой репозитория."
+                    return 1
                 fi
                 git --git-dir="$GITHUB_STORE" update-ref -d "$local_ref" || return 1
                 git --git-dir="$GITHUB_STORE" update-ref -d "$remote_ref" || return 1

--- a/remote-control/remote-control-essence.sh
+++ b/remote-control/remote-control-essence.sh
@@ -273,7 +273,7 @@ github_enable_local() {
             return 1
         fi
         if [[ $GITHUB_STORAGE_MODE == age ]] && {
-            _github_ensure_deps age || ! github_config_age_init
+            ! _github_ensure_deps age || ! github_config_age_init
         }; then
             _github_record_error "настройка шифрования конфигурации" \
                 "Не удалось подготовить ключи шифрования."
@@ -321,7 +321,8 @@ github_enable_local() {
                 return 1
                 ;;
         esac
-        if [[ $GITHUB_STORAGE_MODE == age ]] && ! _github_ensure_deps age; then
+        if ! _github_storage_read ||
+           { [[ $GITHUB_STORAGE_MODE == age ]] && ! _github_ensure_deps age; }; then
             _github_record_error "чтение существующей конфигурации GitHub" \
                 "Не удалось проверить или расшифровать существующую конфигурацию. Репозиторий не изменён."
             _github_enable_rollback "$source_backup" "$source_had_file"

--- a/remote-control/remote-control-essence.sh
+++ b/remote-control/remote-control-essence.sh
@@ -118,17 +118,9 @@ _materialize_script_auth_from_state() {
 
 # ─── Текущая нода (глобальные переменные) ────────────────────────────────────
 NODE_NAME=""
-_config_source_materialize_github() {
-    local logical="${1:-$CONFIG_DIR/runtime-vault.json}"
-    local runtime="${2:-$CONFIG_DIR/github-runtime}"
+_config_source_materialize_state() {
+    local logical="${1:?logical state}" runtime="${2:-$CONFIG_DIR/github-runtime}"
     local name
-    [[ -n "${GITHUB_WORKTREE:-}" && -d "$GITHUB_WORKTREE" ]] || return 1
-    if ! github_config_open "$GITHUB_WORKTREE" "$logical"; then
-        _github_record_error "чтение конфигурации GitHub" \
-            "Не удалось проверить или расшифровать состояние репозитория."
-        return 1
-    fi
-    _materialize_script_auth_from_state "$logical" || return 1
     rm -rf "$runtime"
     mkdir -p "$runtime/templates" "$runtime/ssh/identities" || return 1
     jq -e '.config' "$logical" > "$runtime/config.json" || return 1
@@ -158,6 +150,18 @@ _config_source_materialize_github() {
     SSH_IDENTITIES_DIR="$runtime/ssh/identities"; SSH_KNOWN_HOSTS="$runtime/ssh/known_hosts"
     SCRIPT_AUTH_FILE="$CONFIG_DIR/.auth"
     state_validate true >/dev/null
+}
+
+_config_source_materialize_github() {
+    local logical="${1:-$CONFIG_DIR/runtime-vault.json}"
+    [[ -n "${GITHUB_WORKTREE:-}" && -d "$GITHUB_WORKTREE" ]] || return 1
+    if ! github_config_open "$GITHUB_WORKTREE" "$logical"; then
+        _github_record_error "чтение конфигурации GitHub" \
+            "Не удалось проверить или расшифровать состояние репозитория."
+        return 1
+    fi
+    _materialize_script_auth_from_state "$logical" || return 1
+    _config_source_materialize_state "$logical" "${2:-$CONFIG_DIR/github-runtime}"
 }
 
 
@@ -228,11 +232,10 @@ _github_enable_rollback() {
 github_enable_local() {
     [[ $CONFIG_SOURCE == local ]] || return 0
     _github_clear_error
-    local source_backup source_had_file=false tmp_state=""
-    if ! _github_prompt_storage_mode; then
-        _github_record_error "выбор способа хранения" "Выбор источника GitHub отменён."
+    if ! _github_select_account; then
         return 1
     fi
+    local source_backup source_had_file=false tmp_state="" tracked
     if [[ -z ${CONFIG_DIR:-} ]] || ! mkdir -p "$CONFIG_DIR"; then
         _github_record_error "подготовка локальной конфигурации" \
             "Не удалось подготовить каталог конфигурации."
@@ -252,84 +255,135 @@ github_enable_local() {
             return 1
         }
     fi
-    if ! mkdir -p "$CONFIG_DIR" "$TEMPLATES_DIR" "$SSH_IDENTITIES_DIR" \
-        "$(dirname "$SSH_KNOWN_HOSTS")"; then
-        _github_record_error "подготовка локальной конфигурации" \
-            "Не удалось создать служебные каталоги."
-        _github_enable_rollback "$source_backup" "$source_had_file"
-        return 1
-    fi
-    if [[ ! -f "$CONFIG_JSON" ]] &&
-       ! printf '%s\n' '{"schema_version":2,"nodes":[],"groups":[],"clients":[],"connections":[]}' \
-           > "$CONFIG_JSON"; then
-        _github_record_error "подготовка локальной конфигурации" \
-            "Не удалось создать config.json."
-        _github_enable_rollback "$source_backup" "$source_had_file"
-        return 1
-    fi
-    if [[ ! -f "$SECRETS_JSON" ]] &&
-       ! printf '%s\n' '{"schema_version":1,"node_passwords":{}}' > "$SECRETS_JSON"; then
-        _github_record_error "подготовка локальной конфигурации" \
-            "Не удалось создать файл с защищёнными данными."
-        _github_enable_rollback "$source_backup" "$source_had_file"
-        return 1
-    fi
-    if [[ ! -f "$STATE_MANIFEST" ]] &&
-       ! printf '%s\n' '{"schema_version":2,"portability":{"status":"ready","issues":[]},"templates":{}}' \
-           > "$STATE_MANIFEST"; then
-        _github_record_error "подготовка локальной конфигурации" \
-            "Не удалось создать служебное описание конфигурации."
-        _github_enable_rollback "$source_backup" "$source_had_file"
-        return 1
-    fi
-    github_sync_init true || {
+    github_sync_init true onboarding || {
         _github_enable_rollback "$source_backup" "$source_had_file"
         return 1
     }
-    if [[ $GITHUB_STORAGE_MODE == age ]] && {
-        _github_ensure_deps age || ! github_config_age_init
-    }; then
-        _github_record_error "настройка шифрования конфигурации" \
-            "Не удалось подготовить ключи шифрования."
-        _github_enable_rollback "$source_backup" "$source_had_file"
-        return 1
-    fi
-    CONFIG_SOURCE=github
-    if ! _github_initial_portable_onboarding; then
-        _github_record_error "подготовка переносимой конфигурации" \
-            "Не удалось подготовить локальные файлы для хранения в GitHub."
-        _github_enable_rollback "$source_backup" "$source_had_file"
-        return 1
-    fi
-    tmp_state=$(umask 077; mktemp "$CONFIG_DIR/.vault.XXXXXX") || {
-        _github_record_error "подготовка конфигурации к отправке" \
-            "Не удалось создать защищённый временный файл."
+    tracked=$(git -C "$GITHUB_WORKTREE" ls-files) || {
+        _github_record_error "проверка существующего репозитория GitHub" \
+            "Не удалось проверить содержимое репозитория GitHub. Репозиторий не изменён."
         _github_enable_rollback "$source_backup" "$source_had_file"
         return 1
     }
-    if ! github_config_serialize "$tmp_state" "$CONFIG_JSON" ||
-       ! github_config_checkpoint "$tmp_state"; then
-        _github_record_error "подготовка конфигурации к отправке" \
-            "Не удалось собрать конфигурацию для репозитория GitHub."
-        _github_enable_rollback "$source_backup" "$source_had_file" "$tmp_state"
-        return 1
-    fi
-    rm -f "$tmp_state"
-    tmp_state=""
-    github_sync_flush || {
-        GITHUB_SYNC_STATUS=pending
-        warn "Изменения сохранены локально и не отправлены."
-    }
-    if ! _config_source_materialize_github; then
-        _github_record_error "проверка подключённого источника" \
-            "Не удалось открыть конфигурацию из репозитория GitHub после подключения."
-        _github_enable_rollback "$source_backup" "$source_had_file"
-        return 1
+
+    if [[ -z "$tracked" ]]; then
+        if ! _github_prompt_storage_mode; then
+            _github_record_error "выбор способа хранения" "Выбор источника GitHub отменён."
+            _github_enable_rollback "$source_backup" "$source_had_file"
+            return 1
+        fi
+        if [[ $GITHUB_STORAGE_MODE == age ]] && {
+            _github_ensure_deps age || ! github_config_age_init
+        }; then
+            _github_record_error "настройка шифрования конфигурации" \
+                "Не удалось подготовить ключи шифрования."
+            _github_enable_rollback "$source_backup" "$source_had_file"
+            return 1
+        fi
+        CONFIG_SOURCE=github
+        if ! _github_initial_portable_onboarding; then
+            _github_record_error "подготовка переносимой конфигурации" \
+                "Не удалось подготовить локальные файлы для хранения в GitHub."
+            _github_enable_rollback "$source_backup" "$source_had_file"
+            return 1
+        fi
+        tmp_state=$(umask 077; mktemp "$CONFIG_DIR/.vault.XXXXXX") || {
+            _github_record_error "подготовка конфигурации к отправке" \
+                "Не удалось создать защищённый временный файл."
+            _github_enable_rollback "$source_backup" "$source_had_file"
+            return 1
+        }
+        if ! github_config_serialize "$tmp_state" "$CONFIG_JSON" ||
+           ! github_config_checkpoint "$tmp_state"; then
+            _github_record_error "подготовка конфигурации к отправке" \
+                "Не удалось собрать конфигурацию для репозитория GitHub."
+            _github_enable_rollback "$source_backup" "$source_had_file" "$tmp_state"
+            return 1
+        fi
+        github_sync_flush || {
+            GITHUB_SYNC_STATUS=pending
+            warn "Изменения сохранены локально и не отправлены."
+        }
+        if ! _materialize_script_auth_from_state "$tmp_state" ||
+           ! _config_source_materialize_state "$tmp_state"; then
+            _github_record_error "проверка подключённого источника" \
+                "Не удалось открыть конфигурацию из репозитория GitHub после подключения."
+            _github_enable_rollback "$source_backup" "$source_had_file" "$tmp_state"
+            return 1
+        fi
+    else
+        case $'\n'"$tracked"$'\n' in
+            *$'\nstorage.json\n'*) ;;
+            *)
+                _github_record_error "проверка существующего репозитория GitHub" \
+                    "В репозитории есть данные, но отсутствует корректная конфигурация Essence. Репозиторий не изменён."
+                _github_enable_rollback "$source_backup" "$source_had_file"
+                return 1
+                ;;
+        esac
+        if [[ $GITHUB_STORAGE_MODE == age ]] && ! _github_ensure_deps age; then
+            _github_record_error "чтение существующей конфигурации GitHub" \
+                "Не удалось проверить или расшифровать существующую конфигурацию. Репозиторий не изменён."
+            _github_enable_rollback "$source_backup" "$source_had_file"
+            return 1
+        fi
+        tmp_state=$(umask 077; mktemp "$CONFIG_DIR/.vault.XXXXXX") || {
+            _github_record_error "чтение существующей конфигурации GitHub" \
+                "Не удалось проверить или расшифровать существующую конфигурацию. Репозиторий не изменён."
+            _github_enable_rollback "$source_backup" "$source_had_file"
+            return 1
+        }
+        if ! github_config_open "$GITHUB_WORKTREE" "$tmp_state"; then
+            _github_record_error "чтение существующей конфигурации GitHub" \
+                "Не удалось проверить или расшифровать существующую конфигурацию. Репозиторий не изменён."
+            _github_enable_rollback "$source_backup" "$source_had_file" "$tmp_state"
+            return 1
+        fi
+        if ! _github_prompt_existing_config_action; then
+            _github_record_error "выбор версии конфигурации" "Подключение GitHub отменено."
+            _github_enable_rollback "$source_backup" "$source_had_file" "$tmp_state"
+            return 1
+        fi
+        CONFIG_SOURCE=github
+        if [[ "$GITHUB_EXISTING_ACTION" == remote ]]; then
+            if ! _materialize_script_auth_from_state "$tmp_state" ||
+               ! _config_source_materialize_state "$tmp_state"; then
+                _github_record_error "проверка подключённого источника" \
+                    "Не удалось открыть конфигурацию из репозитория GitHub после подключения."
+                _github_enable_rollback "$source_backup" "$source_had_file" "$tmp_state"
+                return 1
+            fi
+        else
+            if ! _github_initial_portable_onboarding; then
+                _github_record_error "подготовка переносимой конфигурации" \
+                    "Не удалось подготовить локальные файлы для хранения в GitHub."
+                _github_enable_rollback "$source_backup" "$source_had_file" "$tmp_state"
+                return 1
+            fi
+            if ! github_config_serialize "$tmp_state" "$CONFIG_JSON" ||
+               ! github_config_checkpoint "$tmp_state"; then
+                _github_record_error "подготовка конфигурации к отправке" \
+                    "Не удалось собрать конфигурацию для репозитория GitHub."
+                _github_enable_rollback "$source_backup" "$source_had_file" "$tmp_state"
+                return 1
+            fi
+            github_sync_flush || {
+                GITHUB_SYNC_STATUS=pending
+                warn "Изменения сохранены локально и не отправлены."
+            }
+            if ! _materialize_script_auth_from_state "$tmp_state" ||
+               ! _config_source_materialize_state "$tmp_state"; then
+                _github_record_error "проверка подключённого источника" \
+                    "Не удалось открыть конфигурацию из репозитория GitHub после подключения."
+                _github_enable_rollback "$source_backup" "$source_had_file" "$tmp_state"
+                return 1
+            fi
+        fi
     fi
     export CONFIG_SOURCE CONFIG_JSON SECRETS_JSON STATE_MANIFEST TEMPLATES_DIR
     export SSH_IDENTITIES_DIR SSH_KNOWN_HOSTS SCRIPT_AUTH_FILE STATE_DIR
     if ! github_source_metadata_write; then
-        _github_enable_rollback "$source_backup" "$source_had_file"
+        _github_enable_rollback "$source_backup" "$source_had_file" "$tmp_state"
         return 1
     fi
     if [[ "$CONFIG_SOURCE" != github ]] ||
@@ -337,10 +391,10 @@ github_enable_local() {
        ! github_source_metadata_valid "$CONFIG_DIR/source.json"; then
         _github_record_error "проверка подключённого источника" \
             "Не удалось сохранить или проверить настройки источника GitHub."
-        _github_enable_rollback "$source_backup" "$source_had_file"
+        _github_enable_rollback "$source_backup" "$source_had_file" "$tmp_state"
         return 1
     fi
-    rm -f "$source_backup"
+    rm -f "$tmp_state" "$source_backup"
     success "Источник GitHub подключён."
 }
 
@@ -383,6 +437,7 @@ github_source_menu() {
         box_line " I) Импортировать ключ восстановления" " ${YELLOW}I)${NC} Импортировать ключ восстановления"
     fi
     box_line " E) Использовать локальную конфигурацию без синхронизации с GitHub" " ${RED}E)${NC} Использовать локальную конфигурацию без синхронизации с GitHub"
+    box_line " D) Удалить репозиторий GitHub" " ${RED}D)${NC} Удалить репозиторий GitHub"
     box_line " 0) Назад"
     box_bot
     echo ""
@@ -428,6 +483,26 @@ github_source_menu() {
         E|e)
             github_config_switch_local &&
                 success "Используется локальная конфигурация; синхронизация с GitHub отключена."
+            ;;
+        D|d)
+            local _repo_to_delete
+            _repo_to_delete=$(_github_repo)
+            warn "Будет удалён репозиторий GitHub: $_repo_to_delete."
+            warn "Конфигурация останется локально, синхронизация будет отключена."
+            if confirm_yn "Удалить репозиторий $_repo_to_delete?" N; then
+                if github_repository_delete "$_repo_to_delete"; then
+                    success "Репозиторий $_repo_to_delete удалён. Конфигурация сохранена локально, синхронизация отключена."
+                else
+                    _github_report_last_error "Не удалось удалить репозиторий GitHub"
+                    if [[ "$GITHUB_LAST_STAGE" == "удаление репозитория GitHub" ]]; then
+                        if github_repository_open_settings "$_repo_to_delete"; then
+                            info "Открыта страница настроек $_repo_to_delete. Завершите удаление в Danger Zone."
+                        else
+                            warn "Откройте страницу настроек и завершите удаление в Danger Zone: $(hyperlink "https://github.com/$_repo_to_delete/settings")"
+                        fi
+                    fi
+                fi
+            fi
             ;;
         0|"") return 0 ;;
         *) warn "Неверный выбор." ;;

--- a/tests/unit/github_plaintext_source.bats
+++ b/tests/unit/github_plaintext_source.bats
@@ -567,10 +567,27 @@ chmod +x "$BIN/age" "$BIN/age-keygen"
 EOF
     chmod +x "$BIN/brew"
     export PM=brew AGE_INSTALL_MARKER="$BATS_TEST_TMPDIR/age-install-marker"
+    local original_path="$PATH"
+    local isolated_bin="$BATS_TEST_TMPDIR/no-age-bin" path_dir candidate name
+    mkdir -p "$isolated_bin"
+    while IFS= read -r path_dir; do
+        [[ -d "$path_dir" ]] || continue
+        for candidate in "$path_dir"/*; do
+            [[ -f "$candidate" && -x "$candidate" ]] || continue
+            name=${candidate##*/}
+            case "$name" in age|age-keygen) continue ;; esac
+            [[ -e "$isolated_bin/$name" ]] ||
+                ln -s "$candidate" "$isolated_bin/$name"
+        done
+    done < <(tr ':' '\n' <<< "$PATH")
+    export PATH="$BIN:$isolated_bin"
+    ! command -v age >/dev/null 2>&1
+
 
 
     run bash -c 'printf "Y\n1\naccess-pass\nn\n1\n0\n" | "$0"' \
         "$APP/remote-control-essence.sh"
+    export PATH="$original_path"
     assert_success
     assert_output --partial "Отсутствует age — устанавливаем age через brew"
     [[ -f "$AGE_INSTALL_MARKER" ]]

--- a/tests/unit/github_plaintext_source.bats
+++ b/tests/unit/github_plaintext_source.bats
@@ -418,6 +418,40 @@ EOF
     assert_output --partial "Источник GitHub подключён."
     git --git-dir="$REMOTE" show-ref --verify --quiet refs/heads/main
 }
+@test "encrypted GitHub source initializes empty private repository and restarts" {
+    git --git-dir="$REMOTE" update-ref -d refs/heads/main
+    _install_fake_age
+
+    run bash -c 'printf "1\n0\n" | "$0"' "$APP/remote-control-essence.sh"
+    assert_success
+    run bash -c 'printf "Y\n1\n1\naccess-pass\naccess-pass\n0\n" | "$0"' \
+        "$APP/remote-control-essence.sh"
+    assert_success
+    local config_dir="$HOME/.config/remote-control-essence"
+    assert_output --partial "Источник GitHub подключён."
+    jq -e '.type == "github" and .private_verified == true' \
+        "$config_dir/source.json"
+    [[ "$(git --git-dir="$config_dir/github-store.git" show main:storage.json |
+        jq -r '.encryption')" == age ]]
+    local rel
+    for rel in recipient.txt unlock.age state.json.age; do
+        git --git-dir="$config_dir/github-store.git" cat-file -e "main:$rel"
+    done
+    for rel in config.json secrets.json manifest.json; do
+        ! git --git-dir="$config_dir/github-store.git" cat-file -e "main:$rel"
+    done
+    [[ -f "$config_dir/github-runtime/config.json" ]]
+
+    run bash -c 'printf "access-pass\nn\n0\n" | "$0"' \
+        "$APP/remote-control-essence.sh"
+    assert_success
+    assert_output --partial "синхронизировано"
+
+    run bash -c 'printf "access-pass\nn\nY\n0\n0\n" | "$0"' \
+        "$APP/remote-control-essence.sh"
+    assert_success
+    assert_output --partial "Сменить пароль доступа"
+}
 
 @test "script password hash persists through GitHub and protects the next process" {
     run bash -c 'printf "1\n0\n" | "$0"' "$APP/remote-control-essence.sh"
@@ -498,6 +532,8 @@ EOF
 
     local updater="$BATS_TEST_TMPDIR/age-existing"
     git clone "$REMOTE" "$updater" >/dev/null
+    git -C "$updater" config user.name updater
+    git -C "$updater" config user.email updater@example.invalid
     mkdir -p "$updater/templates" "$updater/ssh"
     jq -n --slurpfile config "$config_dir/config.json" \
         --slurpfile secrets "$config_dir/secrets.json" \
@@ -519,10 +555,25 @@ EOF
     git -C "$updater" add -A
     git -C "$updater" commit -m encrypted-state >/dev/null
     git -C "$updater" push origin main >/dev/null
+    mv "$BIN/age" "$BIN/age.package"
+    mv "$BIN/age-keygen" "$BIN/age-keygen.package"
+    cat > "$BIN/brew" <<'EOF'
+#!/bin/bash
+[[ "$1" == install && "$2" == age ]] || exit 1
+cp "$BIN/age.package" "$BIN/age"
+cp "$BIN/age-keygen.package" "$BIN/age-keygen"
+chmod +x "$BIN/age" "$BIN/age-keygen"
+: > "$AGE_INSTALL_MARKER"
+EOF
+    chmod +x "$BIN/brew"
+    export PM=brew AGE_INSTALL_MARKER="$BATS_TEST_TMPDIR/age-install-marker"
+
 
     run bash -c 'printf "Y\n1\naccess-pass\nn\n1\n0\n" | "$0"' \
         "$APP/remote-control-essence.sh"
     assert_success
+    assert_output --partial "Отсутствует age — устанавливаем age через brew"
+    [[ -f "$AGE_INSTALL_MARKER" ]]
     assert_output --partial "режим хранения: зашифровано паролем"
     [[ "$output" != *"Зашифровать паролем"* ]]
     [[ "$output" != *"Хранить без шифрования"* ]]

--- a/tests/unit/github_plaintext_source.bats
+++ b/tests/unit/github_plaintext_source.bats
@@ -183,10 +183,15 @@ fi
 EOF
     cat > "$BIN/age" <<'EOF'
 #!/bin/bash
-out="" input=""
+out="" input="" decrypting=false
 while [[ $# -gt 0 ]]; do
     case "$1" in
-        -d|-p) shift ;;
+        -d) decrypting=true; shift ;;
+        -p)
+            if [[ "$decrypting" == true && -n "${AGE_PASSWORD_DECRYPT_MARKER:-}" ]]; then
+                printf '%s\n' unlock >> "$AGE_PASSWORD_DECRYPT_MARKER"
+            fi
+            shift ;;
         -r|-i) shift 2 ;;
         -o) out="$2"; shift 2 ;;
         *) input="$1"; shift ;;
@@ -567,6 +572,8 @@ chmod +x "$BIN/age" "$BIN/age-keygen"
 EOF
     chmod +x "$BIN/brew"
     export PM=brew AGE_INSTALL_MARKER="$BATS_TEST_TMPDIR/age-install-marker"
+    export AGE_PASSWORD_DECRYPT_MARKER="$BATS_TEST_TMPDIR/age-password-decrypts"
+    : > "$AGE_PASSWORD_DECRYPT_MARKER"
     local original_path="$PATH"
     local isolated_bin="$BATS_TEST_TMPDIR/no-age-bin" path_dir candidate name
     mkdir -p "$isolated_bin"
@@ -594,12 +601,9 @@ EOF
     assert_output --partial "режим хранения: зашифровано паролем"
     [[ "$output" != *"Зашифровать паролем"* ]]
     [[ "$output" != *"Хранить без шифрования"* ]]
-    local prompt="Введите пароль доступа к конфигурации" password_prompts=0 remaining="$output"
-    while [[ "$remaining" == *"$prompt"* ]]; do
-        password_prompts=$((password_prompts + 1))
-        remaining=${remaining#*"$prompt"}
-    done
-    [[ "$password_prompts" == 1 ]]
+    local password_decrypts
+    password_decrypts=$(wc -l < "$AGE_PASSWORD_DECRYPT_MARKER" | tr -d ' ')
+    [[ "$password_decrypts" == 1 ]]
     [[ "$(jq -r '.marker' "$config_dir/github-runtime/config.json")" == remote ]]
     [[ "$(jq -r '.marker' "$config_dir/config.json")" == local ]]
 }

--- a/tests/unit/github_plaintext_source.bats
+++ b/tests/unit/github_plaintext_source.bats
@@ -9,7 +9,9 @@ setup() {
     export BIN="$BATS_TEST_TMPDIR/bin"
     export REMOTE="$BATS_TEST_TMPDIR/remote.git"
     export GIT_CONFIG_GLOBAL="$BATS_TEST_TMPDIR/gitconfig"
+    export GH_ACTIVE_LOGIN_FILE="$BATS_TEST_TMPDIR/gh-active-login"
     mkdir -p "$APP/modules" "$APP/templates" "$APP/common/protocols" "$BIN" "$HOME"
+    printf '%s\n' test-owner > "$GH_ACTIVE_LOGIN_FILE"
     cp "$PROJECT_ROOT/remote-control/remote-control-essence.sh" "$APP/"
     cp "$PROJECT_ROOT/remote-control/modules/"*.sh "$APP/modules/"
     cp "$PROJECT_ROOT/remote-control/templates/"*.yaml "$APP/templates/"
@@ -32,6 +34,15 @@ if [[ "$1" == auth && "$2" == status ]]; then
     fi
     exit 0
 fi
+if [[ "$1" == auth && "$2" == switch ]]; then
+    if [[ "${GH_MODE:-success}" == auth-switch-fail ]]; then
+        printf '%s\n' 'switch failed: token=ghp_SwitchSecret123' >&2
+        exit 1
+    fi
+    printf '%s\n' alternate-owner > "$GH_ACTIVE_LOGIN_FILE"
+    [[ -z "${GH_SWITCH_MARKER:-}" ]] || touch "$GH_SWITCH_MARKER"
+    exit 0
+fi
 if [[ "$1" == auth && "$2" == setup-git ]]; then
     exit 0
 fi
@@ -40,7 +51,7 @@ if [[ "$1" == api && "$2" == user ]]; then
         printf '%s\n' 'HTTP 401: Bad credentials' >&2
         exit 1
     fi
-    printf '%s\n' 'test-owner'
+    cat "$GH_ACTIVE_LOGIN_FILE"
     exit 0
 fi
 if [[ "$1" == repo && "$2" == view ]]; then
@@ -50,6 +61,10 @@ if [[ "$1" == repo && "$2" == view ]]; then
     fi
     if [[ "${GH_MODE:-success}" == secret-fail ]]; then
         printf '%s\n' 'permission denied: https://user:password@github.com token=ghp_SecretValue123456789 github_pat_SecretValue123456789' >&2
+        exit 1
+    fi
+    if [[ "${GH_MODE:-success}" == missing ]]; then
+        printf '%s\n' 'repository not found' >&2
         exit 1
     fi
     if [[ "${GH_MODE:-success}" == retry ]]; then
@@ -77,6 +92,19 @@ if [[ "$1" == repo && "$2" == create ]]; then
     fi
     printf '%s\n' '{"visibility":"PRIVATE"}'
     exit 0
+fi
+if [[ "$1" == repo && "$2" == delete ]]; then
+    [[ -z "${GH_DELETE_MARKER:-}" ]] || touch "$GH_DELETE_MARKER"
+    if [[ "${GH_DELETE_FAIL:-false}" == true ]]; then
+        printf '%s\n' 'delete failed: token=ghp_DeleteSecret123' >&2
+        exit 1
+    fi
+    exit 0
+fi
+if [[ "$1" == browse && "$2" == --settings && "$3" == --repo ]]; then
+    [[ -z "${GH_BROWSE_MARKER:-}" ]] || touch "$GH_BROWSE_MARKER"
+    [[ "${GH_BROWSE_FAIL:-false}" != true ]]
+    exit $?
 fi
 exit 1
 EOF
@@ -169,6 +197,36 @@ cp "$input" "$out"
 EOF
     chmod +x "$BIN/age" "$BIN/age-keygen"
 }
+_set_local_marker() {
+    local config_dir="$1" marker="$2" tmp="$BATS_TEST_TMPDIR/config-marker.tmp"
+    jq --arg marker "$marker" '.marker=$marker' "$config_dir/config.json" > "$tmp" &&
+        mv "$tmp" "$config_dir/config.json"
+}
+
+_publish_plain_marker() {
+    local marker="$1" updater="$BATS_TEST_TMPDIR/plain-marker-$marker"
+    git clone "$REMOTE" "$updater" >/dev/null
+    git -C "$updater" config user.name updater
+    git -C "$updater" config user.email updater@example.invalid
+    jq --arg marker "$marker" '.marker=$marker' "$updater/config.json" \
+        > "$updater/config.json.tmp" && mv "$updater/config.json.tmp" "$updater/config.json"
+    git -C "$updater" add config.json
+    git -C "$updater" commit -m "marker-$marker" >/dev/null
+    git -C "$updater" push origin main >/dev/null
+}
+
+
+_prepare_existing_plaintext_vault() {
+    run bash -c 'printf "1\n0\n" | "$0"' "$APP/remote-control-essence.sh"
+    assert_success
+    local config_dir="$HOME/.config/remote-control-essence"
+    _set_local_marker "$config_dir" local
+    run bash -c 'printf "Y\n1\n2\n0\n" | "$0"' "$APP/remote-control-essence.sh"
+    assert_success
+    run bash -c 'printf "Y\nE\n0\n" | "$0"' "$APP/remote-control-essence.sh"
+    assert_success
+}
+
 
 
 @test "first local source selection does not probe GitHub" {
@@ -189,7 +247,7 @@ EOF
     [[ "$output" == *$'\033[0;32m1)\033[0m Хранить конфигурацию только на этом компьютере'* ]]
     [[ "$output" == *$'\033[0;36m2)\033[0m Синхронизировать конфигурацию через GitHub'* ]]
 
-    run bash -c 'printf "Y\n2\n0\n" | "$0"' "$APP/remote-control-essence.sh"
+    run bash -c 'printf "Y\n1\n2\n0\n" | "$0"' "$APP/remote-control-essence.sh"
     assert_success
     local config_dir="$HOME/.config/remote-control-essence"
     local github_link=$'\033]8;;https://github.com/test-owner/essence-remote-control-config\033\\GitHub\033]8;;\033\\'
@@ -257,7 +315,7 @@ EOF
     _install_fake_age
     run bash -c 'printf "1\n0\n" | "$0"' "$APP/remote-control-essence.sh"
     assert_success
-    run bash -c 'printf "Y\n2\n0\n" | "$0"' "$APP/remote-control-essence.sh"
+    run bash -c 'printf "Y\n1\n2\n0\n" | "$0"' "$APP/remote-control-essence.sh"
     assert_success
 
     local updater="$BATS_TEST_TMPDIR/age-updater"
@@ -302,7 +360,7 @@ EOF
 @test "ready GitHub state with nodes does not show deferred SSH action" {
     run bash -c 'printf "1\n0\n" | "$0"' "$APP/remote-control-essence.sh"
     assert_success
-    run bash -c 'printf "Y\n2\n0\n" | "$0"' "$APP/remote-control-essence.sh"
+    run bash -c 'printf "Y\n1\n2\n0\n" | "$0"' "$APP/remote-control-essence.sh"
     assert_success
     _publish_key_node_state ready
 
@@ -315,7 +373,7 @@ EOF
 @test "deferred SSH action is visible only until mocked setup resolves issues" {
     run bash -c 'printf "1\n0\n" | "$0"' "$APP/remote-control-essence.sh"
     assert_success
-    run bash -c 'printf "Y\n2\n0\n" | "$0"' "$APP/remote-control-essence.sh"
+    run bash -c 'printf "Y\n1\n2\n0\n" | "$0"' "$APP/remote-control-essence.sh"
     assert_success
     _publish_key_node_state needs-setup
 
@@ -355,7 +413,7 @@ EOF
 
     run bash -c 'printf "1\n0\n" | "$0"' "$APP/remote-control-essence.sh"
     assert_success
-    run bash -c 'printf "Y\n2\n0\n" | "$0"' "$APP/remote-control-essence.sh"
+    run bash -c 'printf "Y\n1\n2\n0\n" | "$0"' "$APP/remote-control-essence.sh"
     assert_success
     assert_output --partial "Источник GitHub подключён."
     git --git-dir="$REMOTE" show-ref --verify --quiet refs/heads/main
@@ -364,7 +422,7 @@ EOF
 @test "script password hash persists through GitHub and protects the next process" {
     run bash -c 'printf "1\n0\n" | "$0"' "$APP/remote-control-essence.sh"
     assert_success
-    run bash -c 'printf "Y\n2\n0\n" | "$0"' "$APP/remote-control-essence.sh"
+    run bash -c 'printf "Y\n1\n2\n0\n" | "$0"' "$APP/remote-control-essence.sh"
     assert_success
 
     run bash -c 'printf "L\nsecret-pass\nsecret-pass\n0\n" | "$0"' "$APP/remote-control-essence.sh"
@@ -377,6 +435,129 @@ EOF
     assert_output --partial "Essence Remote Management"
     [[ "$output" != *"Доступ запрещён."* ]]
 }
+@test "existing plaintext vault can load remote without changing local files" {
+    _prepare_existing_plaintext_vault
+    _publish_plain_marker remote
+    local config_dir="$HOME/.config/remote-control-essence"
+    local remote_head
+    remote_head=$(git --git-dir="$REMOTE" rev-parse main)
+
+    run bash -c 'printf "Y\n1\n1\n0\n" | "$0"' "$APP/remote-control-essence.sh"
+    assert_success
+    assert_output --partial "В GitHub уже сохранена конфигурация (режим хранения: без шифрования)."
+    assert_output --partial "1) Загрузить конфигурацию из GitHub"
+    [[ "$output" != *"Зашифровать паролем"* ]]
+    [[ "$output" != *"Хранить без шифрования"* ]]
+    [[ "$(jq -r '.marker' "$config_dir/github-runtime/config.json")" == remote ]]
+    [[ "$(jq -r '.marker' "$config_dir/config.json")" == local ]]
+    [[ "$(git --git-dir="$REMOTE" rev-parse main)" == "$remote_head" ]]
+    jq -e '.type == "github" and .repo == "test-owner/essence-remote-control-config"' \
+        "$config_dir/source.json"
+}
+
+@test "existing plaintext vault can replace remote with local history" {
+    _prepare_existing_plaintext_vault
+    _publish_plain_marker remote
+    local config_dir="$HOME/.config/remote-control-essence"
+    _set_local_marker "$config_dir" local-new
+    local old_remote new_remote
+    old_remote=$(git --git-dir="$REMOTE" rev-parse main)
+
+    run bash -c 'printf "Y\n1\n2\n0\n" | "$0"' "$APP/remote-control-essence.sh"
+    assert_success
+    new_remote=$(git --git-dir="$REMOTE" rev-parse main)
+    [[ "$new_remote" != "$old_remote" ]]
+    git --git-dir="$REMOTE" merge-base --is-ancestor "$old_remote" "$new_remote"
+    [[ "$(git --git-dir="$REMOTE" show "$old_remote:config.json" | jq -r '.marker')" == remote ]]
+    [[ "$(git --git-dir="$REMOTE" show "$new_remote:config.json" | jq -r '.marker')" == local-new ]]
+    [[ "$(jq -r '.marker' "$config_dir/github-runtime/config.json")" == local-new ]]
+}
+
+@test "canceling existing plaintext vault keeps both versions untouched" {
+    _prepare_existing_plaintext_vault
+    _publish_plain_marker remote
+    local config_dir="$HOME/.config/remote-control-essence"
+    local checksum remote_head
+    checksum=$(_hash_file "$config_dir/config.json")
+    remote_head=$(git --git-dir="$REMOTE" rev-parse main)
+
+    run bash -c 'printf "Y\n1\n0\n0\n" | "$0"' "$APP/remote-control-essence.sh"
+    assert_success
+    assert_output --partial "выбор версии конфигурации"
+    [[ ! -e "$config_dir/source.json" ]]
+    [[ "$(_hash_file "$config_dir/config.json")" == "$checksum" ]]
+    [[ "$(git --git-dir="$REMOTE" rev-parse main)" == "$remote_head" ]]
+}
+
+@test "existing age vault inherits storage mode and unlocks only once" {
+    _install_fake_age
+    run bash -c 'printf "1\n0\n" | "$0"' "$APP/remote-control-essence.sh"
+    assert_success
+    local config_dir="$HOME/.config/remote-control-essence"
+    _set_local_marker "$config_dir" local
+
+    local updater="$BATS_TEST_TMPDIR/age-existing"
+    git clone "$REMOTE" "$updater" >/dev/null
+    mkdir -p "$updater/templates" "$updater/ssh"
+    jq -n --slurpfile config "$config_dir/config.json" \
+        --slurpfile secrets "$config_dir/secrets.json" \
+        --rawfile template "$APP/templates/default.yaml" '
+        {
+          vault_version:1,
+          minimum_remote_control_version:"0.0.0",
+          portability:{status:"ready",issues:[]},
+          access:{script_password_hash:null},
+          config:($config[0] + {marker:"remote"}),
+          secrets:$secrets[0],
+          templates:{"default.yaml":{content:$template}},
+          ssh:{identities:{},known_hosts:""}
+        }
+    ' > "$updater/state.json.age"
+    printf '%s\n' '{"storage_version":1,"encryption":"age"}' > "$updater/storage.json"
+    printf '%s\n' age1testrecipient > "$updater/recipient.txt"
+    printf '%s\n' AGE-SECRET-KEY-TEST > "$updater/unlock.age"
+    git -C "$updater" add -A
+    git -C "$updater" commit -m encrypted-state >/dev/null
+    git -C "$updater" push origin main >/dev/null
+
+    run bash -c 'printf "Y\n1\naccess-pass\nn\n1\n0\n" | "$0"' \
+        "$APP/remote-control-essence.sh"
+    assert_success
+    assert_output --partial "режим хранения: зашифровано паролем"
+    [[ "$output" != *"Зашифровать паролем"* ]]
+    [[ "$output" != *"Хранить без шифрования"* ]]
+    local password_prompts
+    password_prompts=$(printf '%s' "$output" |
+        grep -o 'Введите пароль доступа к конфигурации' | wc -l | tr -d ' ')
+    [[ "$password_prompts" == 1 ]]
+    [[ "$(jq -r '.marker' "$config_dir/github-runtime/config.json")" == remote ]]
+    [[ "$(jq -r '.marker' "$config_dir/config.json")" == local ]]
+}
+@test "tracked GitHub data without storage metadata is rejected before writing" {
+    run bash -c 'printf "1\n0\n" | "$0"' "$APP/remote-control-essence.sh"
+    assert_success
+    local config_dir="$HOME/.config/remote-control-essence"
+    local checksum remote_head orphan="$BATS_TEST_TMPDIR/orphan"
+    checksum=$(_hash_file "$config_dir/config.json")
+    git init -b main "$orphan" >/dev/null
+    git -C "$orphan" config user.name orphan
+    git -C "$orphan" config user.email orphan@example.invalid
+    printf 'not an Essence vault\n' > "$orphan/README.txt"
+    git -C "$orphan" add README.txt
+    git -C "$orphan" commit -m orphan >/dev/null
+    git -C "$orphan" remote add origin "$REMOTE"
+    git -C "$orphan" push --force origin main >/dev/null
+    remote_head=$(git --git-dir="$REMOTE" rev-parse main)
+
+    run bash -c 'printf "Y\n1\n0\n" | "$0"' "$APP/remote-control-essence.sh"
+    assert_success
+    assert_output --partial "проверка существующего репозитория GitHub"
+    assert_output --partial "В репозитории есть данные, но отсутствует корректная конфигурация Essence."
+    [[ ! -e "$config_dir/source.json" ]]
+    [[ "$(_hash_file "$config_dir/config.json")" == "$checksum" ]]
+    [[ "$(git --git-dir="$REMOTE" rev-parse main)" == "$remote_head" ]]
+}
+
 
 
 @test "failed GitHub enable preserves local source and config" {
@@ -386,7 +567,7 @@ EOF
     local checksum
     checksum=$(_hash_file "$config_dir/config.json")
 
-    run env GH_MODE=fail bash -c 'printf "Y\n2\n0\n" | "$0"' "$APP/remote-control-essence.sh"
+    run env GH_MODE=fail bash -c 'printf "Y\n1\n0\n" | "$0"' "$APP/remote-control-essence.sh"
     assert_success
     assert_output --partial "Не удалось подключить GitHub (этап: проверка приватного репозитория): permission denied"
     assert_output --partial "GitHub-аккаунт для репозитория конфигурации: test-owner"
@@ -403,7 +584,7 @@ EOF
     export GH_MODE=retry GH_COUNT_FILE="$BATS_TEST_TMPDIR/gh-count"
     printf '0\n' > "$GH_COUNT_FILE"
 
-    run bash -c 'printf "Y\n2\nY\n2\n0\n" | "$0"' "$APP/remote-control-essence.sh"
+    run bash -c 'printf "Y\n1\nY\n1\n2\n0\n" | "$0"' "$APP/remote-control-essence.sh"
     assert_success
     assert_output --partial "Не удалось подключить GitHub (этап: проверка приватного репозитория): permission denied"
     [[ "$output" != *"gh auth login"* ]]
@@ -415,20 +596,36 @@ EOF
 @test "confirmed GitHub auth failure shows relevant login hint" {
     run bash -c 'printf "1\n0\n" | "$0"' "$APP/remote-control-essence.sh"
     assert_success
+    export GH_CALLS_FILE="$BATS_TEST_TMPDIR/gh-calls"
 
-    run env GH_MODE=auth-fail bash -c 'printf "Y\n2\n0\n" | "$0"' "$APP/remote-control-essence.sh"
+    run env GH_MODE=auth-fail bash -c 'printf "Y\n1\n0\n" | "$0"' "$APP/remote-control-essence.sh"
     assert_success
     assert_output --partial "Не удалось подключить GitHub (этап: определение пользователя GitHub): HTTP 401: Bad credentials"
     assert_output --partial "Выполните: gh auth login"
     assert_output --partial "Продолжаем использовать локальную конфигурацию."
     [[ "$output" == *"Источник конфигурации: локальный"* ]]
+    [[ "$(grep -c '^repo view ' "$GH_CALLS_FILE" || true)" == 0 ]]
+    [[ "$(grep -c '^repo create ' "$GH_CALLS_FILE" || true)" == 0 ]]
 }
 
+@test "failed GitHub account switch stops before repository operations" {
+    run bash -c 'printf "1\n0\n" | "$0"' "$APP/remote-control-essence.sh"
+    assert_success
+    export GH_CALLS_FILE="$BATS_TEST_TMPDIR/gh-calls"
+
+    run env GH_MODE=auth-switch-fail bash -c 'printf "Y\n2\n0\n" | "$0"' "$APP/remote-control-essence.sh"
+    assert_success
+    assert_output --partial "Не удалось подключить GitHub (этап: переключение аккаунта GitHub): switch failed: token=[скрыто]"
+    assert_output --partial "gh auth login"
+    [[ "$output" != *"ghp_SwitchSecret123"* ]]
+    [[ "$(grep -c '^repo view ' "$GH_CALLS_FILE" || true)" == 0 ]]
+    [[ "$(grep -c '^repo create ' "$GH_CALLS_FILE" || true)" == 0 ]]
+}
 @test "GitHub connection error redacts credentials and tokens" {
     run bash -c 'printf "1\n0\n" | "$0"' "$APP/remote-control-essence.sh"
     assert_success
 
-    run env GH_MODE=secret-fail bash -c 'printf "Y\n2\n0\n" | "$0"' "$APP/remote-control-essence.sh"
+    run env GH_MODE=secret-fail bash -c 'printf "Y\n1\n0\n" | "$0"' "$APP/remote-control-essence.sh"
     assert_success
     assert_output --partial "Не удалось подключить GitHub (этап: проверка приватного репозитория):"
     assert_output --partial "[скрыто]"
@@ -445,10 +642,10 @@ EOF
     printf '0\n' > "$GH_CREATE_COUNT_FILE"
     run bash -c 'printf "1\n0\n" | "$0"' "$APP/remote-control-essence.sh"
     assert_success
-    run bash -c 'printf "Y\n2\n0\n" | "$0"' "$APP/remote-control-essence.sh"
+    run bash -c 'printf "Y\n1\ny\n2\n0\n" | "$0"' "$APP/remote-control-essence.sh"
     assert_success
 
-    run bash -c 'printf "Y\nE\nY\n2\n0\n" | "$0"' "$APP/remote-control-essence.sh"
+    run bash -c 'printf "Y\nE\nY\n1\n2\n0\n" | "$0"' "$APP/remote-control-essence.sh"
     assert_success
     assert_output --partial "Источник GitHub подключён."
     [[ "$output" != *"Не удалось подключить GitHub"* ]]
@@ -477,7 +674,7 @@ EOF
 @test "switching from GitHub to local persists without source metadata" {
     run bash -c 'printf "1\n0\n" | "$0"' "$APP/remote-control-essence.sh"
     assert_success
-    run bash -c 'printf "Y\n2\n0\n" | "$0"' "$APP/remote-control-essence.sh"
+    run bash -c 'printf "Y\n1\n2\n0\n" | "$0"' "$APP/remote-control-essence.sh"
     assert_success
     local config_dir="$HOME/.config/remote-control-essence"
 
@@ -493,4 +690,163 @@ EOF
     [[ "$output" != *"source.json содержит неподдерживаемый"* ]]
     [[ "$(_hash_file "$config_dir/config.json")" == "$checksum" ]]
     [[ ! -e "$config_dir/source.json" ]]
+}
+@test "selecting another GitHub account happens before repository operations" {
+    local alternate_remote="$BATS_TEST_TMPDIR/alternate.git"
+    local alternate_seed="$BATS_TEST_TMPDIR/alternate-seed"
+    git init --bare -b main "$alternate_remote" >/dev/null
+    git init -b main "$alternate_seed" >/dev/null
+    git -C "$alternate_seed" config user.name seed
+    git -C "$alternate_seed" config user.email seed@example.invalid
+    git -C "$alternate_seed" commit --allow-empty -m seed >/dev/null
+    git -C "$alternate_seed" remote add origin "$alternate_remote"
+    git -C "$alternate_seed" push origin main >/dev/null
+    git config --global url."file://$alternate_remote".insteadOf \
+        "https://github.com/alternate-owner/essence-remote-control-config.git"
+    export GH_CALLS_FILE="$BATS_TEST_TMPDIR/gh-calls"
+    export GH_SWITCH_MARKER="$BATS_TEST_TMPDIR/gh-switch"
+
+    run bash -c 'printf "1\n0\n" | "$0"' "$APP/remote-control-essence.sh"
+    assert_success
+    run bash -c 'printf "Y\n2\n1\n2\n0\n" | "$0"' "$APP/remote-control-essence.sh"
+    assert_success
+
+    local config_dir="$HOME/.config/remote-control-essence"
+    jq -e '.repo == "alternate-owner/essence-remote-control-config"' \
+        "$config_dir/source.json"
+    [[ -f "$GH_SWITCH_MARKER" ]]
+    local calls
+    calls=$(cat "$GH_CALLS_FILE")
+    [[ "$calls" == *$'api user --jq .login\nauth switch --hostname github.com\napi user --jq .login'* ]]
+    [[ "$calls" != *"repo view test-owner/essence-remote-control-config"* ]]
+    [[ "$calls" == *"repo view alternate-owner/essence-remote-control-config"* ]]
+    [[ "$(git --git-dir="$config_dir/github-store.git" config --get remote.origin.url)" == "https://github.com/alternate-owner/essence-remote-control-config.git" ]]
+}
+
+@test "missing repository defaults to refusal without creating or changing local state" {
+    run bash -c 'printf "1\n0\n" | "$0"' "$APP/remote-control-essence.sh"
+    assert_success
+    local config_dir="$HOME/.config/remote-control-essence"
+    local checksum
+    checksum=$(_hash_file "$config_dir/config.json")
+    export GH_MODE=missing GH_CALLS_FILE="$BATS_TEST_TMPDIR/gh-calls"
+    export GH_CREATE_COUNT_FILE="$BATS_TEST_TMPDIR/gh-create-count"
+    printf '0\n' > "$GH_CREATE_COUNT_FILE"
+
+    run bash -c 'printf "Y\n1\n\n0\n" | "$0"' "$APP/remote-control-essence.sh"
+    assert_output --partial "Репозиторий test-owner/essence-remote-control-config не найден."
+    assert_output --partial "Продолжаем использовать локальную конфигурацию."
+    [[ "$(_hash_file "$config_dir/config.json")" == "$checksum" ]]
+    [[ ! -e "$config_dir/source.json" ]]
+    [[ "$(cat "$GH_CREATE_COUNT_FILE")" == 0 ]]
+    [[ "$(grep -c '^repo create ' "$GH_CALLS_FILE" || true)" == 0 ]]
+}
+
+@test "confirmed missing repository creates exactly one private repository" {
+    export GH_MODE=missing GH_CALLS_FILE="$BATS_TEST_TMPDIR/gh-calls"
+    export GH_CREATE_COUNT_FILE="$BATS_TEST_TMPDIR/gh-create-count"
+    printf '0\n' > "$GH_CREATE_COUNT_FILE"
+
+    run bash -c 'printf "1\n0\n" | "$0"' "$APP/remote-control-essence.sh"
+    assert_success
+    run bash -c 'printf "Y\n1\ny\n2\n0\n" | "$0"' "$APP/remote-control-essence.sh"
+    assert_success
+
+    [[ "$(cat "$GH_CREATE_COUNT_FILE")" == 1 ]]
+    [[ "$(grep -c '^repo create test-owner/essence-remote-control-config --private --description Essence Remote Control configuration$' "$GH_CALLS_FILE" || true)" == 1 ]]
+    jq -e '.type == "github" and .private_verified == true' \
+        "$HOME/.config/remote-control-essence/source.json"
+}
+
+@test "startup does not recreate a repository missing from saved GitHub source" {
+    export GH_MODE=missing GH_CALLS_FILE="$BATS_TEST_TMPDIR/gh-calls"
+    export GH_CREATE_COUNT_FILE="$BATS_TEST_TMPDIR/gh-create-count"
+    printf '0\n' > "$GH_CREATE_COUNT_FILE"
+
+    run bash -c 'printf "1\n0\n" | "$0"' "$APP/remote-control-essence.sh"
+    assert_success
+    run bash -c 'printf "Y\n1\ny\n2\n0\n" | "$0"' "$APP/remote-control-essence.sh"
+    assert_success
+    printf '0\n' > "$GH_CREATE_COUNT_FILE"
+
+    run bash -c 'printf "0\n" | "$0"' "$APP/remote-control-essence.sh"
+    assert_failure
+    assert_output --partial "Не удалось открыть источник GitHub (этап: проверка приватного репозитория): Репозиторий test-owner/essence-remote-control-config не найден."
+    [[ "$(cat "$GH_CREATE_COUNT_FILE")" == 0 ]]
+    [[ "$(grep -c '^repo create ' "$GH_CALLS_FILE" || true)" == 1 ]]
+}
+
+@test "GitHub delete defaults to refusal and keeps source metadata" {
+    run bash -c 'printf "1\n0\n" | "$0"' "$APP/remote-control-essence.sh"
+    assert_success
+    run bash -c 'printf "Y\n1\n2\n0\n" | "$0"' "$APP/remote-control-essence.sh"
+    assert_success
+    local config_dir="$HOME/.config/remote-control-essence"
+    export GH_CALLS_FILE="$BATS_TEST_TMPDIR/gh-calls"
+    export GH_DELETE_MARKER="$BATS_TEST_TMPDIR/gh-delete"
+
+    run bash -c 'printf "Y\nD\n\n0\n" | "$0"' "$APP/remote-control-essence.sh"
+    assert_success
+    [[ -f "$config_dir/source.json" ]]
+    [[ ! -e "$GH_DELETE_MARKER" ]]
+    [[ "$(grep -c '^repo delete ' "$GH_CALLS_FILE" || true)" == 0 ]]
+}
+
+@test "successful GitHub delete preserves local files and disables source" {
+    run bash -c 'printf "1\n0\n" | "$0"' "$APP/remote-control-essence.sh"
+    assert_success
+    run bash -c 'printf "Y\n1\n2\n0\n" | "$0"' "$APP/remote-control-essence.sh"
+    assert_success
+    local config_dir="$HOME/.config/remote-control-essence"
+    export GH_CALLS_FILE="$BATS_TEST_TMPDIR/gh-calls"
+    export GH_DELETE_MARKER="$BATS_TEST_TMPDIR/gh-delete"
+
+    run bash -c 'printf "Y\nD\ny\n0\n" | "$0"' "$APP/remote-control-essence.sh"
+    assert_success
+    assert_output --partial "Репозиторий test-owner/essence-remote-control-config удалён."
+    assert_output --partial "Источник конфигурации: локальный"
+    [[ -f "$GH_DELETE_MARKER" ]]
+    [[ "$(grep -c '^repo delete test-owner/essence-remote-control-config --yes$' "$GH_CALLS_FILE" || true)" == 1 ]]
+    [[ ! -e "$config_dir/source.json" ]]
+    jq -e 'type == "object" and .schema_version == 2' "$config_dir/config.json"
+    jq -e 'type == "object" and .schema_version == 1' "$config_dir/secrets.json"
+    jq -e 'type == "object" and .schema_version == 2' "$config_dir/manifest.json"
+}
+
+@test "failed GitHub delete opens settings and keeps local source" {
+    run bash -c 'printf "1\n0\n" | "$0"' "$APP/remote-control-essence.sh"
+    assert_success
+    run bash -c 'printf "Y\n1\n2\n0\n" | "$0"' "$APP/remote-control-essence.sh"
+    assert_success
+    local config_dir="$HOME/.config/remote-control-essence"
+    export GH_CALLS_FILE="$BATS_TEST_TMPDIR/gh-calls"
+    export GH_DELETE_MARKER="$BATS_TEST_TMPDIR/gh-delete"
+    export GH_BROWSE_MARKER="$BATS_TEST_TMPDIR/gh-browse"
+    export GH_DELETE_FAIL=true
+
+    run bash -c 'printf "Y\nD\ny\n0\n" | "$0"' "$APP/remote-control-essence.sh"
+    assert_success
+    assert_output --partial "Открыта страница настроек test-owner/essence-remote-control-config"
+    [[ -f "$config_dir/config.json" ]]
+    [[ ! -e "$config_dir/source.json" ]]
+    [[ -f "$GH_DELETE_MARKER" && -f "$GH_BROWSE_MARKER" ]]
+    [[ "$(grep -c '^repo delete test-owner/essence-remote-control-config --yes$' "$GH_CALLS_FILE" || true)" == 1 ]]
+    [[ "$(grep -c '^browse --settings --repo test-owner/essence-remote-control-config$' "$GH_CALLS_FILE" || true)" == 1 ]]
+    [[ "$output" != *"ghp_DeleteSecret123"* ]]
+}
+
+@test "failed settings fallback prints a clickable repository settings link" {
+    run bash -c 'printf "1\n0\n" | "$0"' "$APP/remote-control-essence.sh"
+    assert_success
+    run bash -c 'printf "Y\n1\n2\n0\n" | "$0"' "$APP/remote-control-essence.sh"
+    assert_success
+    local config_dir="$HOME/.config/remote-control-essence"
+    export GH_CALLS_FILE="$BATS_TEST_TMPDIR/gh-calls"
+    export GH_DELETE_FAIL=true GH_BROWSE_FAIL=true
+
+    run bash -c 'printf "Y\nD\ny\n0\n" | "$0"' "$APP/remote-control-essence.sh"
+    assert_success
+    assert_output --partial "https://github.com/test-owner/essence-remote-control-config/settings"
+    [[ ! -e "$config_dir/source.json" ]]
+    [[ "$output" != *"ghp_DeleteSecret123"* ]]
 }

--- a/tests/unit/github_plaintext_source.bats
+++ b/tests/unit/github_plaintext_source.bats
@@ -594,9 +594,11 @@ EOF
     assert_output --partial "режим хранения: зашифровано паролем"
     [[ "$output" != *"Зашифровать паролем"* ]]
     [[ "$output" != *"Хранить без шифрования"* ]]
-    local password_prompts
-    password_prompts=$(printf '%s' "$output" |
-        grep -o 'Введите пароль доступа к конфигурации' | wc -l | tr -d ' ')
+    local prompt="Введите пароль доступа к конфигурации" password_prompts=0 remaining="$output"
+    while [[ "$remaining" == *"$prompt"* ]]; do
+        password_prompts=$((password_prompts + 1))
+        remaining=${remaining#*"$prompt"}
+    done
     [[ "$password_prompts" == 1 ]]
     [[ "$(jq -r '.marker' "$config_dir/github-runtime/config.json")" == remote ]]
     [[ "$(jq -r '.marker' "$config_dir/config.json")" == local ]]

--- a/tests/unit/github_sync.bats
+++ b/tests/unit/github_sync.bats
@@ -165,7 +165,7 @@ _file_mode() {
     github_sync_init true onboarding
     [[ "$(git -C "$GITHUB_WORKTREE" rev-parse HEAD)" == "$remote_oid" ]]
     [[ "$(git --git-dir="$GITHUB_STORE" rev-parse main)" == "$remote_oid" ]]
-    [[ "$(git --git-dir="$GITHUB_STORE" rev-parse refs/archive/onboarding-*)" == "$local_oid" ]]
+    [[ "$(git --git-dir="$GITHUB_STORE" for-each-ref --format='%(objectname)' 'refs/archive/onboarding-*')" == "$local_oid" ]]
     [[ "$(git --git-dir="$REMOTE" rev-parse main)" == "$remote_oid" ]]
 }
 
@@ -189,7 +189,7 @@ _file_mode() {
     empty_oid=$(git --git-dir="$GITHUB_STORE" rev-parse main)
     [[ "$empty_oid" != "$cached_oid" ]]
     [[ -z "$(git -C "$GITHUB_WORKTREE" ls-files)" ]]
-    [[ "$(git --git-dir="$GITHUB_STORE" rev-parse refs/archive/onboarding-*)" == "$cached_oid" ]]
+    [[ "$(git --git-dir="$GITHUB_STORE" for-each-ref --format='%(objectname)' 'refs/archive/onboarding-*')" == "$cached_oid" ]]
     github_config_close
 
     local missing="$BATS_TEST_TMPDIR/missing.git" before

--- a/tests/unit/github_sync.bats
+++ b/tests/unit/github_sync.bats
@@ -195,8 +195,9 @@ _file_mode() {
     local missing="$BATS_TEST_TMPDIR/missing.git" before
     before=$(git --git-dir="$GITHUB_STORE" rev-parse main)
     GITHUB_REMOTE="$missing"
-    run github_sync_init true onboarding
-    assert_failure
+    if github_sync_init true onboarding; then
+        return 1
+    fi
     [[ "$GITHUB_LAST_STAGE" == "загрузка репозитория GitHub" ]]
     [[ "$(git --git-dir="$GITHUB_STORE" rev-parse main)" == "$before" ]]
 }

--- a/tests/unit/github_sync.bats
+++ b/tests/unit/github_sync.bats
@@ -125,6 +125,82 @@ _file_mode() {
     [[ "$(git --git-dir="$GITHUB_STORE" show main:storage.json | jq -r '.revision')" == 2 ]]
 }
 
+@test "onboarding archives divergent cached main and opens remote head" {
+    local seed="$BATS_TEST_TMPDIR/seed"
+    git init --bare -b main "$REMOTE" >/dev/null
+    git init -b main "$seed" >/dev/null
+    git -C "$seed" config user.name seed
+    git -C "$seed" config user.email seed@example.invalid
+    printf '{"storage_version":1,"encryption":"none","revision":"base"}\n' \
+        > "$seed/storage.json"
+    git -C "$seed" add storage.json
+    git -C "$seed" commit -m base >/dev/null
+    git -C "$seed" remote add origin "$REMOTE"
+    git -C "$seed" push origin main >/dev/null
+
+    github_sync_init
+    local base_oid
+    base_oid=$(git --git-dir="$GITHUB_STORE" rev-parse main)
+    github_config_close
+    local tree local_oid
+    tree=$(git --git-dir="$GITHUB_STORE" rev-parse "$base_oid^{tree}")
+    local_oid=$(printf 'offline local state\n' |
+        git -c user.name='Essence Remote Control' \
+            -c user.email='remote-control@localhost' \
+            --git-dir="$GITHUB_STORE" commit-tree "$tree" -p "$base_oid")
+    git --git-dir="$GITHUB_STORE" update-ref refs/heads/main "$local_oid"
+
+    local updater="$BATS_TEST_TMPDIR/updater"
+    git clone "$REMOTE" "$updater" >/dev/null
+    git -C "$updater" config user.name updater
+    git -C "$updater" config user.email updater@example.invalid
+    printf '{"storage_version":1,"encryption":"none","revision":"remote"}\n' \
+        > "$updater/storage.json"
+    git -C "$updater" add storage.json
+    git -C "$updater" commit -m remote >/dev/null
+    git -C "$updater" push origin main >/dev/null
+    local remote_oid
+    remote_oid=$(git --git-dir="$REMOTE" rev-parse main)
+
+    github_sync_init true onboarding
+    [[ "$(git -C "$GITHUB_WORKTREE" rev-parse HEAD)" == "$remote_oid" ]]
+    [[ "$(git --git-dir="$GITHUB_STORE" rev-parse main)" == "$remote_oid" ]]
+    [[ "$(git --git-dir="$GITHUB_STORE" rev-parse refs/archive/onboarding-*)" == "$local_oid" ]]
+    [[ "$(git --git-dir="$REMOTE" rev-parse main)" == "$remote_oid" ]]
+}
+
+@test "onboarding confirms empty remote and rejects network errors" {
+    local seed="$BATS_TEST_TMPDIR/seed"
+    git init -b main "$seed" >/dev/null
+    git -C "$seed" config user.name seed
+    git -C "$seed" config user.email seed@example.invalid
+    git -C "$seed" commit --allow-empty -m cached >/dev/null
+    git -C "$seed" remote add origin "$REMOTE"
+    git -C "$seed" push origin main >/dev/null
+
+    github_sync_init
+    local cached_oid
+    cached_oid=$(git --git-dir="$GITHUB_STORE" rev-parse main)
+    github_config_close
+    git --git-dir="$REMOTE" update-ref -d refs/heads/main
+
+    github_sync_init true onboarding
+    local empty_oid
+    empty_oid=$(git --git-dir="$GITHUB_STORE" rev-parse main)
+    [[ "$empty_oid" != "$cached_oid" ]]
+    [[ -z "$(git -C "$GITHUB_WORKTREE" ls-files)" ]]
+    [[ "$(git --git-dir="$GITHUB_STORE" rev-parse refs/archive/onboarding-*)" == "$cached_oid" ]]
+    github_config_close
+
+    local missing="$BATS_TEST_TMPDIR/missing.git" before
+    before=$(git --git-dir="$GITHUB_STORE" rev-parse main)
+    GITHUB_REMOTE="$missing"
+    run github_sync_init true onboarding
+    assert_failure
+    [[ "$GITHUB_LAST_STAGE" == "загрузка репозитория GitHub" ]]
+    [[ "$(git --git-dir="$GITHUB_STORE" rev-parse main)" == "$before" ]]
+}
+
 @test "switching repository updates origin and never pushes new data to old remote" {
     github_sync_init
     printf '{"storage_version":1,"encryption":"none","revision":1}\n' \


### PR DESCRIPTION
## Что изменено
- разделены режимы resume и onboarding синхронизации GitHub;
- добавлено архивирование локальных состояний и обработка пустого репозитория;
- добавлен выбор загрузки удалённой или локальной версии существующей конфигурации;
- добавлены сценарии для plaintext и age-хранилищ, отмены и повреждённых данных.

## Проверка
- `bash -n remote-control/modules/github-config.sh remote-control/remote-control-essence.sh`
- `bash tests/run_tests.sh --all` — 351 unit и 40 fuzz тестов.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added GitHub account selection during setup.
  - Added options to open repository settings or delete repositories, with confirmation and fallback guidance.
  - Added support for resuming setup with existing repositories and choosing local or remote configuration.
  - Added encrypted or plaintext storage options.
  - Improved handling of empty or conflicting repositories, including safe history archiving.

- **Bug Fixes**
  - Improved validation and error reporting for invalid repositories and network failures.
  - Preserved local configuration when synchronization cannot complete.
  - Improved credential handling to prevent sensitive information from appearing in output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->